### PR TITLE
Wrong month displayed

### DIFF
--- a/static/js/show.js
+++ b/static/js/show.js
@@ -346,7 +346,7 @@ function updateTime(diff) {
 	$('#time').html("<div class='time'>"
 		+ "<strong >" + days[time.day] + ", " 
 		+ now.getDate() + "." 
-		+ now.getMonth() + "." 
+		+ (now.getMonth()+1) + "." 
 		+ now.getFullYear() 
 		+ "<br />"
 		+ time.hours + ":" + time.mins + edit_btn  + "</strong></div>");


### PR DESCRIPTION
Hi Michi,

corrected a little bug in displaying the current month number as JS `Date.getMonth()` is zero-indexed.
